### PR TITLE
Remove eventemitter3 dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - Update phaser-ce to version 2.10.6 (see #34).
 
-- Update eventemmiter3 to version 3.1.10 (see #34).
+- Remove eventemitter3 dependency (see #45).
 
 - Add changelog (see #35).
 
@@ -27,8 +27,6 @@
 - Update TypeScript Compiler Options (see #43).
 
 - Enforce TSLint rules (see #44).
-
-- Remove eventemitter3 dependency (see #45).
 
 - Update dev dependencies to latest version.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
 
 - Enforce TSLint rules (see #44).
 
+- Remove eventemitter3 dependency (see #45).
+
 - Update dev dependencies to latest version.
 
 ### [v0.0.5](https://github.com/RobotlegsJS/RobotlegsJS-Phaser/releases/tag/0.0.5) - 2017-09-26

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
   "homepage": "https://github.com/RobotlegsJS/RobotlegsJS-Phaser#readme",
   "dependencies": {
     "@robotlegsjs/core": "^0.1.3",
-    "eventemitter3": "^3.1.0",
     "phaser-ce": "^2.10.6"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2073,7 +2073,7 @@ event-emitter@~0.3.5:
     d "1"
     es5-ext "~0.10.14"
 
-eventemitter3@^3.0.0, eventemitter3@^3.1.0:
+eventemitter3@^3.0.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz#090b4d6cdbd645ed10bf750d4b5407942d7ba163"
 


### PR DESCRIPTION
Remove **eventemitter3** dependency since there is no necessity to patch the **phaser-ce** library.