### PR TITLE
Enable view listeners on SceneMediator and ViewMediator classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 #### Major Breaking Changes
 
-- Enable view listeners on `SceneMediator` and `ViewMediator` classes (see #59).
+- Enable view listeners on `SceneMediator` and `ViewMediator` classes (see #56 and #59).
 
   - Methods `addViewListener` and `removeViewListener` were removed from scene and view mediators.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# RobotlegsJS Phaser Changelog:
+# RobotlegsJS Phaser Changelog
 
 ## RobotlegsJS Phaser 1.0.0
 
@@ -18,16 +18,31 @@
 
 - [ ] Migrate [original documentation](https://github.com/robotlegs/robotlegs-framework/blob/master/src/readme.md) and adapt it to TypeScript and Phaser.
 
-## RobotlegsJS Phaser 0.3.0
+## RobotlegsJS Phaser 0.4.0
 
-### v0.3.1
+### v0.4.0
+
+#### Major Breaking Changes
+
+- Enable view listeners on `SceneMediator` and `ViewMediator` classes (see #59).
+
+  - Methods `addViewListener` and `removeViewListener` were removed from scene and view mediators.
+
+  - Added `on`, `once` and `off` methods to the scene and view mediators allowing the mediators to handle events dispatched by `EventEmitter` views.
+
+  - Signature `addContextListener` and `removeContextListener` changed in order to fully support the `IEventDispatcher` interface.
+
+  - New methods `addDomListener` and `removeDomListener` were added to add support to `DOM` events dispatched by an `EventTarget`.
+
+#### Features Or Improvements
 
 - Update dev dependencies to latest version.
 
+## RobotlegsJS Phaser 0.3.0
+
 ### [v0.3.0](https://github.com/RobotlegsJS/RobotlegsJS-Phaser/releases/tag/0.3.0) - 2018-09-10
 
-Major Breaking Changes:
----
+#### Major Breaking Changes
 
 - Add support for `Phaser.GameObject.Container`, allowing the creation of mediators for `Phaser.Scene` and `Phaser.GameObjects.Container` (see #54 and #55).
 
@@ -44,8 +59,7 @@ Major Breaking Changes:
 
   - Package `sceneManager` renamed to `viewManager`
 
-Features Or Improvements:
----
+#### Features Or Improvements
 
 - Update `karma` setup to generate code coverage report only for `src` folder (see #53).
 
@@ -55,8 +69,7 @@ Features Or Improvements:
 
 ### [v0.2.0](https://github.com/RobotlegsJS/RobotlegsJS-Phaser/releases/tag/0.2.0) - 2018-08-07
 
-Major Breaking Changes:
----
+#### Major Breaking Changes
 
 - Implement support for [phaser](https://github.com/photonstorm/phaser) plugin version 3. Suppor for [phaser-ce](https://github.com/photonstorm/phaser-ce) plugin was moved to [RobotlegsJS-Phaser-CE](https://github.com/RobotlegsJS/RobotlegsJS-Phaser-CE) (see #52).
 
@@ -66,8 +79,7 @@ Major Breaking Changes:
 
 - Remove `eventemitter3` dependency (see #45).
 
-Features Or Improvements:
----
+#### Features Or Improvements
 
 - Add changelog (see #35).
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Then follow the [installation instructions](https://github.com/RobotlegsJS/Robot
 
 **Peer Dependencies**
 
++ [eventemitter3](https://github.com/primus/eventemitter3)
 + [Phaser](https://github.com/photonstorm/phaser)
 + [reflect-metadata](https://github.com/rbuckton/reflect-metadata)
 

--- a/example/mediators/MainMediator.ts
+++ b/example/mediators/MainMediator.ts
@@ -25,7 +25,7 @@ export class MainMediator extends SceneMediator<Main> {
 
         this.dispatch(new MainEvent(MainEvent.GAME_START, true, false, { data: this.gameModel }));
 
-        this.scene.input.on("pointerdown", this.onPointerdown, this);
+        this.on(this.scene.input, "pointerdown", this.onPointerdown);
     }
 
     public destroy(): void {

--- a/package.json
+++ b/package.json
@@ -53,9 +53,11 @@
   "homepage": "https://github.com/RobotlegsJS/RobotlegsJS-Phaser#readme",
   "dependencies": {
     "@robotlegsjs/core": "^0.2.1",
+    "@robotlegsjs/eventemitter3": "^0.0.1",
     "tslib": "^1.9.3"
   },
   "peerDependencies": {
+    "eventemitter3": "*",
     "phaser": "^3.11.0",
     "reflect-metadata": "^0.1.12"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ export { IMediatorConfigurator } from "./robotlegs/bender/extensions/mediatorMap
 export { IMediatorMapper } from "./robotlegs/bender/extensions/mediatorMap/dsl/IMediatorMapper";
 export { IMediatorUnmapper } from "./robotlegs/bender/extensions/mediatorMap/dsl/IMediatorUnmapper";
 
+export { AbstractMediator } from "./robotlegs/bender/extensions/mediatorMap/impl/AbstractMediator";
 export { AbstractMediatorFactory } from "./robotlegs/bender/extensions/mediatorMap/impl/AbstractMediatorFactory";
 export { AbstractMediatorHandler } from "./robotlegs/bender/extensions/mediatorMap/impl/AbstractMediatorHandler";
 export { MediatorMapper } from "./robotlegs/bender/extensions/mediatorMap/impl/MediatorMapper";

--- a/src/robotlegs/bender/bundles/phaser/PhaserBundle.ts
+++ b/src/robotlegs/bender/bundles/phaser/PhaserBundle.ts
@@ -7,6 +7,8 @@
 
 import { IBundle, IContext, ILogger, instanceOfType } from "@robotlegsjs/core";
 
+import { LocalEventEmitterMapExtension } from "@robotlegsjs/eventemitter3";
+
 import { IContextSceneManager } from "../../extensions/contextSceneManager/api/IContextSceneManager";
 import { ContextSceneManager } from "../../extensions/contextSceneManager/impl/ContextSceneManager";
 import { ContextSceneManagerListenerConfig } from "../../extensions/contextSceneManager/impl/ContextSceneManagerListenerConfig";
@@ -45,6 +47,7 @@ export class PhaserBundle implements IBundle {
 
         this._context.install(
             ContextSceneManagerExtension,
+            LocalEventEmitterMapExtension,
             SceneManagerExtension,
             SceneManagerObserverExtension,
             SceneMediatorMapExtension,

--- a/src/robotlegs/bender/extensions/mediatorMap/impl/AbstractMediator.ts
+++ b/src/robotlegs/bender/extensions/mediatorMap/impl/AbstractMediator.ts
@@ -28,8 +28,6 @@ export abstract class AbstractMediator implements IMediator {
     @inject(IEventDispatcher)
     protected _eventDispatcher: IEventDispatcher;
 
-    protected _eventEmitter: EventEmitter;
-
     /*============================================================================*/
     /* Public Functions                                                           */
     /*============================================================================*/
@@ -57,54 +55,56 @@ export abstract class AbstractMediator implements IMediator {
     /*============================================================================*/
 
     /**
-     * Use this method to listen for events dispatched by the <code>Phaser.Scene</code> or <code>Phaser.GameObjects.Container</code>
-     * mediated by this mediator. All the registered listeners will be automatically removed when this mediator is destroyed.
+     * Use this method to listen for events dispatched by the <code>EventEmitter</code>.
+     * All the registered listeners will be automatically removed when this mediator is destroyed.
      *
      * Call this method is the same as calling <code>on</code> or <code>addListener</code> directly on the
-     * <code>view</code> emitter, but keeps a list of listeners for easy (usually automatic) removal.
+     * <code>EventEmitter</code>, but keeps a list of listeners for easy (usually automatic) removal.
      *
-     * The <code>context</code> will be automatically set to <code>this</code> when no context information is provided.
+     * The <code>context</code> will be automatically mapped to <code>this</code> when no context information is provided.
      *
+     * @param emitter The <code>EventEmitter</code> to listen to
      * @param event The <code>event</code> type to listen for
      * @param listener The <code>event</code> handler
      * @param context The listener function's "this"
      */
-    protected on(event: string | symbol, listener: EventEmitter.ListenerFn, context?: any): void {
-        this._eventEmitterMap.on(this._eventEmitter, event, listener, context || this);
+    protected on(emitter: EventEmitter, event: string | symbol, listener: EventEmitter.ListenerFn, context?: any): void {
+        this._eventEmitterMap.on(emitter, event, listener, context || this);
     }
 
     /**
-     * Use this method to listen for events dispatched by the <code>Phaser.Scene</code> or <code>Phaser.GameObjects.Container</code>
-     * mediated by this mediator. All the registered listeners will be automatically removed when this mediator is destroyed.
+     * Use this method to listen for events dispatched by the <code>EventEmitter</code>.
+     * All the registered listeners will be automatically removed when this mediator is destroyed.
      *
      * Call this method is the same as calling <code>once</code> directly on the
-     * <code>view</code> emitter, but keeps a list of listeners for easy (usually automatic) removal.
+     * <code>EventEmitter</code>, but keeps a list of listeners for easy (usually automatic) removal.
      *
-     * The <code>context</code> will be automatically set to <code>this</code> when no context information is provided.
+     * The <code>context</code> will be automatically mapped to <code>this</code> when no context information is provided.
      *
+     * @param emitter The <code>EventEmitter</code> to listen to
      * @param event The <code>event</code> type to listen for
      * @param listener The <code>event</code> handler
      * @param context The listener function's "this"
      */
-    protected once(event: string | symbol, listener: EventEmitter.ListenerFn, context?: any): void {
-        this._eventEmitterMap.once(this._eventEmitter, event, listener, context || this);
+    protected once(emitter: EventEmitter, event: string | symbol, listener: EventEmitter.ListenerFn, context?: any): void {
+        this._eventEmitterMap.once(emitter, event, listener, context || this);
     }
 
     /**
-     * Use this method to remove listeners from events dispatched by the <code>Phaser.Scene</code> or <code>Phaser.GameObjects.Container</code>
-     * mediated by this mediator.
+     * Use this method to remove listeners from events dispatched by the <code>EventEmitter</code>.
      *
      * Call this method is the same as calling <code>off</code> directly on the
-     * <code>view</code> emitter, but updates our local list of listeners.
+     * <code>EventEmitter</code> emitter, but updates our local list of listeners.
      *
-     * The <code>context</code> will be automatically set to <code>this</code> when no context information is provided.
+     * The <code>context</code> will be automatically mapped to <code>this</code> when no context information is provided.
      *
+     * @param emitter The <code>EventEmitter</code> to listen to
      * @param event The <code>event</code> type to listen for
      * @param listener The <code>event</code> handler
      * @param contextt The listener function's "this"
      */
-    protected off(event: string | symbol, listener: EventEmitter.ListenerFn, context?: any): void {
-        this._eventEmitterMap.off(this._eventEmitter, event, listener, context || this);
+    protected off(emitter: EventEmitter, event: string | symbol, listener: EventEmitter.ListenerFn, context?: any): void {
+        this._eventEmitterMap.off(emitter, event, listener, context || this);
     }
 
     /**

--- a/src/robotlegs/bender/extensions/mediatorMap/impl/AbstractMediator.ts
+++ b/src/robotlegs/bender/extensions/mediatorMap/impl/AbstractMediator.ts
@@ -1,0 +1,206 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) 2017-present, RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
+import { injectable, inject, IClass, IEvent, IEventDispatcher, Event } from "@robotlegsjs/core";
+
+import { IEventEmitterMap } from "@robotlegsjs/eventemitter3";
+
+import { IMediator } from "../api/IMediator";
+
+import EventEmitter = require("eventemitter3");
+
+/**
+ * Abstract mediator implementation used by <code>SceneMediator</code> and <code>ViewMediator</code> classes.
+ */
+@injectable()
+export abstract class AbstractMediator implements IMediator {
+    /*============================================================================*/
+    /* Protected Properties                                                       */
+    /*============================================================================*/
+
+    @inject(IEventEmitterMap)
+    protected _eventEmitterMap: IEventEmitterMap;
+
+    @inject(IEventDispatcher)
+    protected _eventDispatcher: IEventDispatcher;
+
+    protected _eventEmitter: EventEmitter;
+
+    /*============================================================================*/
+    /* Public Functions                                                           */
+    /*============================================================================*/
+
+    /**
+     * @inheritDoc
+     */
+    public abstract initialize(): void;
+
+    /**
+     * @inheritDoc
+     */
+    public abstract destroy(): void;
+
+    /**
+     * Runs after the mediator has been destroyed.
+     * Cleans up listeners mapped through the local EventEmitterMap.
+     */
+    public postDestroy(): void {
+        this._eventEmitterMap.unmapListeners();
+    }
+
+    /*============================================================================*/
+    /* Protected Functions                                                        */
+    /*============================================================================*/
+
+    /**
+     * Use this method to listen for events dispatched by the <code>Phaser.Scene</code> or <code>Phaser.GameObjects.Container</code>
+     * mediated by this mediator. All the registered listeners will be automatically removed when this mediator is destroyed.
+     *
+     * Call this method is the same as calling <code>on</code> or <code>addListener</code> directly on the
+     * <code>view</code> emitter, but keeps a list of listeners for easy (usually automatic) removal.
+     *
+     * The <code>context</code> will be automatically set to <code>this</code> when no context information is provided.
+     *
+     * @param event The <code>event</code> type to listen for
+     * @param listener The <code>event</code> handler
+     * @param context The listener function's "this"
+     */
+    protected on(event: string | symbol, listener: EventEmitter.ListenerFn, context?: any): void {
+        this._eventEmitterMap.on(this._eventEmitter, event, listener, context || this);
+    }
+
+    /**
+     * Use this method to listen for events dispatched by the <code>Phaser.Scene</code> or <code>Phaser.GameObjects.Container</code>
+     * mediated by this mediator. All the registered listeners will be automatically removed when this mediator is destroyed.
+     *
+     * Call this method is the same as calling <code>once</code> directly on the
+     * <code>view</code> emitter, but keeps a list of listeners for easy (usually automatic) removal.
+     *
+     * The <code>context</code> will be automatically set to <code>this</code> when no context information is provided.
+     *
+     * @param event The <code>event</code> type to listen for
+     * @param listener The <code>event</code> handler
+     * @param context The listener function's "this"
+     */
+    protected once(event: string | symbol, listener: EventEmitter.ListenerFn, context?: any): void {
+        this._eventEmitterMap.once(this._eventEmitter, event, listener, context || this);
+    }
+
+    /**
+     * Use this method to remove listeners from events dispatched by the <code>Phaser.Scene</code> or <code>Phaser.GameObjects.Container</code>
+     * mediated by this mediator.
+     *
+     * Call this method is the same as calling <code>off</code> directly on the
+     * <code>view</code> emitter, but updates our local list of listeners.
+     *
+     * The <code>context</code> will be automatically set to <code>this</code> when no context information is provided.
+     *
+     * @param event The <code>event</code> type to listen for
+     * @param listener The <code>event</code> handler
+     * @param contextt The listener function's "this"
+     */
+    protected off(event: string | symbol, listener: EventEmitter.ListenerFn, context?: any): void {
+        this._eventEmitterMap.off(this._eventEmitter, event, listener, context || this);
+    }
+
+    /**
+     * Use this method to listen for events dispatched by the <code>EventDispatcher/code> provided by RobotlegsJS core.
+     *
+     * Call this method is the same as calling <code>addEventListener</code> directly on the
+     * <code>EventDispatcher</code>, but keeps a list of listeners for easy (usually automatic) removal.
+     *
+     * The <code>context</code> will be automatically set to <code>this</code> when no context information is provided.
+     *
+     * @param event The <code>event</code> type to listen for
+     * @param listener The <code>event</code> handler
+     * @param context The listener function's "this"
+     * @param eventClass Optional Event class for a stronger mapping.
+     * @param useCapture Determines whether the listener works in the capture phase or the bubbling phases.
+     * @param priority The priority level of the event listener.
+     */
+    protected addContextListener(
+        event: string,
+        listener: Function,
+        context?: any,
+        eventClass?: IClass<IEvent>,
+        useCapture?: boolean,
+        priority?: number
+    ): void {
+        this._eventEmitterMap.mapListener(this._eventDispatcher, event, listener, context || this, eventClass, useCapture, priority);
+    }
+
+    /**
+     * Use this method to remove listeners from events dispatched by the <code>EventDispatcher/code> provided by RobotlegsJS core.
+     *
+     * Call this method is the same as calling <code>removeEventListener</code> directly on the
+     * <code>EventDispatcher</code>, but updates our local list of listeners.
+     *
+     * The <code>context</code> will be automatically set to <code>this</code> when no context information is provided.
+     *
+     * @param event The <code>event</code> type to listen for
+     * @param listener The <code>event</code> handler
+     * @param context The listener function's "this"
+     * @param eventClass Optional Event class for a stronger mapping.
+     * @param useCapture Determines whether the listener works in the capture phase or the bubbling phases.
+     * @param priority The priority level of the event listener.
+     */
+    protected removeContextListener(
+        event: string,
+        listener: Function,
+        context?: any,
+        eventClass?: IClass<IEvent>,
+        useCapture?: boolean
+    ): void {
+        this._eventEmitterMap.unmapListener(this._eventDispatcher, event, listener, context || this, eventClass, useCapture);
+    }
+
+    /**
+     * Use this method to listen for DOM events dispatched by the provided <code>EventTarget/code>.
+     *
+     * Call this method is the same as calling <code>addEventListener</code> directly on the
+     * <code>EventTarget</code>, but keeps a list of listeners for easy (usually automatic) removal.
+     *
+     * @param eventTarget The <code>EventTarget</code> to listen to
+     * @param event The <code>Event</code> type to listen for
+     * @param listener The <code>Event</code> handler
+     * @param options An options object that specifies characteristics about the event listener
+     */
+    protected addDomListener(
+        eventTarget: EventTarget,
+        event: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: boolean | AddEventListenerOptions
+    ): void {
+        this._eventEmitterMap.mapDomListener(eventTarget, event, listener, options);
+    }
+
+    /**
+     * Use this method to remove listeners from DOM events dispatched by the provided <code>EventTarget/code>.
+     *
+     * Call this method is the same as calling <code>removeEventListener</code> directly on the
+     * <code>EventTarget</code>, but updates our local list of listeners.
+     *
+     * @param dispatcher The <code>EventTarget</code>
+     * @param event The <code>Event</code> type
+     * @param listener The <code>Event</code> handler
+     * @param options An options object that specifies characteristics about the event listener
+     */
+    protected removeDomListener(eventTarget: EventTarget, event: string, listener: EventListenerOrEventListenerObject): void {
+        this._eventEmitterMap.unmapDomListener(eventTarget, event, listener);
+    }
+
+    /**
+     * Use this method to dispatch events to the Robotlegs context through the <code>EventDispatcher/code> provided by RobotlegsJS core.
+     *
+     * Call this method to trigger the execution of commands, call external services or communicate with other mediators.
+     *
+     * @param event The <code>Event</code> to dispatch
+     */
+    protected dispatch(event: Event): void {
+        this._eventDispatcher.dispatchEvent(event);
+    }
+}

--- a/src/robotlegs/bender/extensions/mediatorMap/impl/SceneMediator.ts
+++ b/src/robotlegs/bender/extensions/mediatorMap/impl/SceneMediator.ts
@@ -23,7 +23,6 @@ export abstract class SceneMediator<T extends Phaser.Scene> extends AbstractMedi
     /*============================================================================*/
 
     public set scene(scene: T) {
-        this._eventEmitter = scene.events;
         this._sceneComponent = scene;
     }
 

--- a/src/robotlegs/bender/extensions/mediatorMap/impl/SceneMediator.ts
+++ b/src/robotlegs/bender/extensions/mediatorMap/impl/SceneMediator.ts
@@ -5,27 +5,17 @@
 //  in accordance with the terms of the license agreement accompanying it.
 // ------------------------------------------------------------------------------
 
-import { injectable, inject, IEventMap, IEventDispatcher, Event } from "@robotlegsjs/core";
+import { injectable } from "@robotlegsjs/core";
 
-import { IMediator } from "../api/IMediator";
+import { AbstractMediator } from "./AbstractMediator";
 
 /**
- * Classic Robotlegs mediator implementation
+ * Classic Robotlegs mediator implementation for the <code>Phaser.Scene</code>.
  *
  * <p>Override initialize and destroy to hook into the mediator lifecycle.</p>
  */
 @injectable()
-export abstract class SceneMediator<T extends Phaser.Scene> implements IMediator {
-    /*============================================================================*/
-    /* Protected Properties                                                       */
-    /*============================================================================*/
-
-    @inject(IEventMap)
-    protected eventMap: IEventMap;
-
-    @inject(IEventDispatcher)
-    protected eventDispatcher: IEventDispatcher;
-
+export abstract class SceneMediator<T extends Phaser.Scene> extends AbstractMediator {
     protected _sceneComponent: T;
 
     /*============================================================================*/
@@ -33,58 +23,11 @@ export abstract class SceneMediator<T extends Phaser.Scene> implements IMediator
     /*============================================================================*/
 
     public set scene(scene: T) {
+        this._eventEmitter = scene.events;
         this._sceneComponent = scene;
     }
 
     public get scene(): T {
         return this._sceneComponent;
-    }
-
-    /*============================================================================*/
-    /* Public Functions                                                           */
-    /*============================================================================*/
-
-    /**
-     * @inheritDoc
-     */
-    public abstract initialize(): void;
-
-    /**
-     * @inheritDoc
-     */
-    public abstract destroy(): void;
-
-    /**
-     * Runs after the mediator has been destroyed.
-     * Cleans up listeners mapped through the local EventMap.
-     */
-    public postDestroy(): void {
-        this.eventMap.unmapListeners();
-    }
-
-    /*============================================================================*/
-    /* Protected Functions                                                        */
-    /*============================================================================*/
-
-    protected addViewListener(eventString: string, listener: Function, eventClass?: Object): void {
-        // this.eventMap.mapListener(this._sceneComponent, eventString, listener, eventClass);
-    }
-
-    protected addContextListener(eventString: string, listener: Function, eventClass?: Object): void {
-        // this.eventMap.mapListener(this.eventDispatcher, eventString, listener, eventClass);
-    }
-
-    protected removeViewListener(eventString: string, listener: Function, eventClass?: Object): void {
-        // this.eventMap.unmapListener(this._sceneComponent, eventString, listener, eventClass);
-    }
-
-    protected removeContextListener(eventString: string, listener: Function, eventClass?: Object): void {
-        // this.eventMap.unmapListener(this.eventDispatcher, eventString, listener, eventClass);
-    }
-
-    protected dispatch(event: Event): void {
-        if (this.eventDispatcher.hasEventListener(event.type)) {
-            this.eventDispatcher.dispatchEvent(event);
-        }
     }
 }

--- a/src/robotlegs/bender/extensions/mediatorMap/impl/ViewMediator.ts
+++ b/src/robotlegs/bender/extensions/mediatorMap/impl/ViewMediator.ts
@@ -5,27 +5,17 @@
 //  in accordance with the terms of the license agreement accompanying it.
 // ------------------------------------------------------------------------------
 
-import { injectable, inject, IEventMap, IEventDispatcher, Event } from "@robotlegsjs/core";
+import { injectable } from "@robotlegsjs/core";
 
-import { IMediator } from "../api/IMediator";
+import { AbstractMediator } from "./AbstractMediator";
 
 /**
- * Classic Robotlegs mediator implementation
+ * Classic Robotlegs mediator implementation for the <code>Phaser.GameObjects.Container</code>.
  *
  * <p>Override initialize and destroy to hook into the mediator lifecycle.</p>
  */
 @injectable()
-export abstract class ViewMediator<T extends Phaser.GameObjects.Container> implements IMediator {
-    /*============================================================================*/
-    /* Protected Properties                                                       */
-    /*============================================================================*/
-
-    @inject(IEventMap)
-    protected eventMap: IEventMap;
-
-    @inject(IEventDispatcher)
-    protected eventDispatcher: IEventDispatcher;
-
+export abstract class ViewMediator<T extends Phaser.GameObjects.Container> extends AbstractMediator {
     protected _viewComponent: T;
 
     /*============================================================================*/
@@ -33,58 +23,11 @@ export abstract class ViewMediator<T extends Phaser.GameObjects.Container> imple
     /*============================================================================*/
 
     public set view(view: T) {
+        this._eventEmitter = view;
         this._viewComponent = view;
     }
 
     public get view(): T {
         return this._viewComponent;
-    }
-
-    /*============================================================================*/
-    /* Public Functions                                                           */
-    /*============================================================================*/
-
-    /**
-     * @inheritDoc
-     */
-    public abstract initialize(): void;
-
-    /**
-     * @inheritDoc
-     */
-    public abstract destroy(): void;
-
-    /**
-     * Runs after the mediator has been destroyed.
-     * Cleans up listeners mapped through the local EventMap.
-     */
-    public postDestroy(): void {
-        this.eventMap.unmapListeners();
-    }
-
-    /*============================================================================*/
-    /* Protected Functions                                                        */
-    /*============================================================================*/
-
-    protected addViewListener(eventString: string, listener: Function, eventClass?: Object): void {
-        //  this.eventMap.mapListener(this._viewComponent, eventString, listener, eventClass);
-    }
-
-    protected addContextListener(eventString: string, listener: Function, eventClass?: Object): void {
-        this.eventMap.mapListener(this.eventDispatcher, eventString, listener, eventClass);
-    }
-
-    protected removeViewListener(eventString: string, listener: Function, eventClass?: Object): void {
-        // this.eventMap.unmapListener(this._viewComponent, eventString, listener, eventClass);
-    }
-
-    protected removeContextListener(eventString: string, listener: Function, eventClass?: Object): void {
-        this.eventMap.unmapListener(this.eventDispatcher, eventString, listener, eventClass);
-    }
-
-    protected dispatch(event: Event): void {
-        if (this.eventDispatcher.hasEventListener(event.type)) {
-            this.eventDispatcher.dispatchEvent(event);
-        }
     }
 }

--- a/src/robotlegs/bender/extensions/mediatorMap/impl/ViewMediator.ts
+++ b/src/robotlegs/bender/extensions/mediatorMap/impl/ViewMediator.ts
@@ -23,7 +23,6 @@ export abstract class ViewMediator<T extends Phaser.GameObjects.Container> exten
     /*============================================================================*/
 
     public set view(view: T) {
-        this._eventEmitter = view;
         this._viewComponent = view;
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -104,27 +104,34 @@
     inversify "^4.13.0"
     tslib "^1.9.3"
 
+"@robotlegsjs/eventemitter3@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.npmjs.org/@robotlegsjs/eventemitter3/-/eventemitter3-0.0.1.tgz#2c25cfce18fbbc0898bbce69048f51fc2e17cce1"
+  dependencies:
+    "@robotlegsjs/core" "^0.2.1"
+    tslib "^1.9.3"
+
 "@sinonjs/commons@^1.0.2":
   version "1.0.2"
   resolved "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.0.2.tgz#3e0ac737781627b8844257fadc3d803997d0526e"
   dependencies:
     type-detect "4.0.8"
 
-"@sinonjs/formatio@3.0.0":
+"@sinonjs/formatio@3.0.0", "@sinonjs/formatio@^3.0.0":
   version "3.0.0"
   resolved "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.0.0.tgz#9d282d81030a03a03fa0c5ce31fd8786a4da311a"
   dependencies:
     "@sinonjs/samsam" "2.1.0"
 
-"@sinonjs/formatio@^2.0.0":
-  version "2.0.0"
-  resolved "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz#84db7e9eb5531df18a8c5e0bfb6e449e55e654b2"
-  dependencies:
-    samsam "1.3.0"
-
-"@sinonjs/samsam@2.1.0", "@sinonjs/samsam@^2.0.0":
+"@sinonjs/samsam@2.1.0":
   version "2.1.0"
   resolved "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.0.tgz#b8b8f5b819605bd63601a6ede459156880f38ea3"
+  dependencies:
+    array-from "^2.1.1"
+
+"@sinonjs/samsam@^2.1.0":
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.1.tgz#f352621c24c9e9ab2ed293a7655e8d46bfd64c16"
   dependencies:
     array-from "^2.1.1"
 
@@ -4489,7 +4496,7 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
 
-nise@^1.4.4:
+nise@^1.4.5:
   version "1.4.5"
   resolved "https://registry.npmjs.org/nise/-/nise-1.4.5.tgz#979a97a19c48d627bb53703726ae8d53ce8d4b3e"
   dependencies:
@@ -5653,10 +5660,6 @@ safe-regex@^1.1.0:
   version "2.1.2"
   resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
 
-samsam@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz#8d1d9350e25622da30de3e44ba692b5221ab7c50"
-
 sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
@@ -5826,16 +5829,16 @@ sinon-chai@^3.2.0:
   resolved "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.2.0.tgz#ed995e13a8a3cfccec18f218d9b767edc47e0715"
 
 sinon@^6.3.2:
-  version "6.3.2"
-  resolved "https://registry.npmjs.org/sinon/-/sinon-6.3.2.tgz#9d5f39689638285683e6625d0f68c4b670d13b36"
+  version "6.3.3"
+  resolved "https://registry.npmjs.org/sinon/-/sinon-6.3.3.tgz#c3a55b7046174c139e87a3c94c922cbf4323a4e7"
   dependencies:
     "@sinonjs/commons" "^1.0.2"
-    "@sinonjs/formatio" "^2.0.0"
-    "@sinonjs/samsam" "^2.0.0"
+    "@sinonjs/formatio" "^3.0.0"
+    "@sinonjs/samsam" "^2.1.0"
     diff "^3.5.0"
     lodash.get "^4.4.2"
     lolex "^2.7.4"
-    nise "^1.4.4"
+    nise "^1.4.5"
     supports-color "^5.5.0"
     type-detect "^4.0.8"
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Enable view listeners on `SceneMediator` and `ViewMediator` classes.

## Related Issue

#56 SceneMediator add/remove viewListener and add/remove contextListener issue

## Motivation and Context

The `SceneMediator` and `ViewMediator` classes currently have these methods commented out:

* `addViewListener`
* `removeViewListener`
* `addContextListener`
* `removeContextListener`

The extension **@robotlegsjs/eventemitter3** is extending the `IEventMap` interface, adding support for events dispatched by one `EventEmitter3` instance.

Now the mediators can receive one instance of an `IEventEmitterMap` through injection and implement the methods mentioned above.

## How Has This Been Tested?

The **example** project is using the new methods.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

* The methods `addViewListener` and `removeViewListener`where renamed to `on`, `once` and `off` to keep correlation between `EventEmitter3` **API**.

```typescript
protected on(
    emitter: EventEmitter,
    event: string | symbol,
    listener: EventEmitter.ListenerFn,
    context?: any
): void {
    this._eventEmitterMap.on(emitter, event, listener, context || this);
}

protected once(
    emitter: EventEmitter,
    event: string | symbol,
    listener: EventEmitter.ListenerFn,
    context?: any
): void {
    this._eventEmitterMap.once(emitter, event, listener, context || this);
}

protected off(
    emitter: EventEmitter,
    event: string | symbol,
    listener: EventEmitter.ListenerFn,
    context?: any
): void {
    this._eventEmitterMap.off(emitter, event, listener, context || this);
}
```

* The signature of the methods `addContextListener` and `removeContextListener` changed in order to fully support the `IEventDispatcher` interface.

```typescript
protected addContextListener(
    event: string,
    listener: Function,
    context?: any,
    eventClass?: IClass<IEvent>,
    useCapture?: boolean,
    priority?: number
): void {
    this._eventEmitterMap.mapListener(
        this._eventDispatcher,
        event,
        listener,
        context || this,
        eventClass,
        useCapture,
        priority
    );
}

protected removeContextListener(
    event: string,
    listener: Function,
    context?: any,
    eventClass?: IClass<IEvent>,
    useCapture?: boolean
): void {
    this._eventEmitterMap.unmapListener(
        this._eventDispatcher,
        event,
        listener,
        context || this,
        eventClass,
        useCapture
    );
}
```

* New methods `addDomListener` and `removeDomListener` where added to add support to **DOM** events dispatched by an `EventTarget`.

```typescript
protected addDomListener(
    eventTarget: EventTarget,
    event: string,
    listener: EventListenerOrEventListenerObject,
    options?: boolean | AddEventListenerOptions
): void {
    this._eventEmitterMap.mapDomListener(eventTarget, event, listener, options);
}

protected removeDomListener(
    eventTarget: EventTarget,
    event: string,
    listener: EventListenerOrEventListenerObject
): void {
    this._eventEmitterMap.unmapDomListener(eventTarget, event, listener);
}
```

- [ ] Updated docs / Refactor code / Added a tests case (non-breaking change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
