### PR TITLE
Add mediator when scene has been started after stop/shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+#### Changed
+
+- Add mediator when scene has been started after stop/shutdown (see #79).
+
 <!--
 Types of changes:
 

--- a/src/robotlegs/bender/extensions/mediatorMap/impl/SceneMediatorManager.ts
+++ b/src/robotlegs/bender/extensions/mediatorMap/impl/SceneMediatorManager.ts
@@ -5,9 +5,8 @@
 //  in accordance with the terms of the license agreement accompanying it.
 // ------------------------------------------------------------------------------
 
-import { IMediatorMapping } from "../api/IMediatorMapping";
 import { IMediatorManager } from "../api/IMediatorManager";
-
+import { IMediatorMapping } from "../api/IMediatorMapping";
 import { SceneMediatorFactory } from "./SceneMediatorFactory";
 
 /**
@@ -54,7 +53,7 @@ export class SceneMediatorManager implements IMediatorManager {
                 this._autoRemoveMap.set(scene.sys.settings.key, scene);
             }
             scene.sys.events.on("destroy", this.onSceneDestroy, this);
-            // scene.sys.events.on("shutdown", this.onSceneDestroy, this);
+            scene.sys.events.on("shutdown", this.onSceneDestroy, this);
             // scene.sys.events.on("sleep", this.onSceneDestroy, this);
             // scene.sys.events.on("pause", this.onSceneDestroy, this);
         }
@@ -81,6 +80,7 @@ export class SceneMediatorManager implements IMediatorManager {
             this._factory.removeMediators(scene);
             if (this._autoRemoveMap.size === 0) {
                 scene.sys.events.off("destroy", this.onSceneDestroy, this, false);
+                scene.sys.events.off("shutdown", this.onSceneDestroy, this, false);
             }
         }
     }

--- a/src/robotlegs/bender/extensions/viewManager/impl/SceneManagerObserver.ts
+++ b/src/robotlegs/bender/extensions/viewManager/impl/SceneManagerObserver.ts
@@ -120,18 +120,28 @@ export class SceneManagerObserver {
                     // this.events.emit('resume', this);
                     // this.events.emit('wake', this);
                     // this.events.emit('start', this);
-                    scene.sys.events.on("start", this.onSceneStart, this);
+                    scene.sys.events.once("start", this.onSceneStart, this);
                 }
             }
         }
     }
 
     private onSceneStart(sys: Phaser.Scenes.Systems): void {
-        sys.events.off("start", this.onSceneStart, this, false);
+        sys.events.once("shutdown", this.onSceneShutdown, this);
+        sys.events.once("destroy", this.onSceneDestroy, this);
         const binding: SceneManagerBinding = this._registry.getBinding(sys.game.scene);
         if (binding) {
             binding.handleScene(sys.scene, <any>sys.scene.constructor);
         }
+    }
+
+    private onSceneShutdown(sys: Phaser.Scenes.Systems): void {
+        sys.events.once("start", this.onSceneStart, this);
+        sys.events.off("destroy", this.onSceneDestroy, this, true);
+    }
+
+    private onSceneDestroy(sys: Phaser.Scenes.Systems): void {
+        sys.events.off("shutdown", this.onSceneStart, this, true);
     }
 
     private removeRootListener(container: any): void {}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Mediator does not crated if scene stop/shutdown and then start again
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#78 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
To be able to stop and start the scene as many times as needed.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Updated docs / Refactor code / Added a tests case (non-breaking change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
